### PR TITLE
Add a `stop` command, pause can unpause

### DIFF
--- a/musicbot/commands/player_commands.py
+++ b/musicbot/commands/player_commands.py
@@ -8,19 +8,21 @@ class PlayerCommands:
 
     @command_info("1.0.0", 1477180800, {
         "3.5.2": (1497712233, "Updated documentaion for this command"),
-        "3.8.9": (1499461647, "Part of the `Giesenesis` rewrite")
+        "3.8.9": (1499461647, "Part of the `Giesenesis` rewrite"),
+        "4.9.9": (1508219627, "Pause can unpause as well just because")
     })
     async def cmd_pause(self, player):
         """
         ///|Usage
         `{command_prefix}pause`
         ///|Explanation
-        Pause playback of the current song.
+        Pause playback of the current song. If the player is paused, it will unpause.
         """
 
         if player.is_playing:
             player.pause()
-
+        elif player.is_paused:
+            player.resume()
         else:
             return Response("Cannot pause what is not playing")
 
@@ -42,6 +44,17 @@ class PlayerCommands:
 
         else:
             return Response("Hard to unpause something that's not paused, amirite?")
+    
+    @command_info("4.9.9", 1508219263)    
+    async def cmd_stop(self, player):
+        """
+        ///|Usage
+        `{command_prefix}stop`
+        ///|Explanation
+        Stops the player completely and removes all entries from the queue.
+        """
+
+        player.kill()
 
     @command_info("1.0.0", 1477180800, {
         "3.5.2": (1497712233, "Updated documentaion for this command"),


### PR DESCRIPTION
- Adds a stop command (`stop`) which clears the queue and stops the player completely. Currently there is no way to do this but use `skip` to end the player and clear the queue. 

- Allows `pause` to `unpause` if the player is paused. Just a convience factor, tiny change.

- Marked as `4.9.9` in the command docs, will take all the changes done in a day or so and put them into the proper changelog when a real release is made; this is just there for the command info log on the server.