### PR TITLE
Fixes `stop` command logic, command docs

### DIFF
--- a/musicbot/commands/player_commands.py
+++ b/musicbot/commands/player_commands.py
@@ -54,7 +54,8 @@ class PlayerCommands:
         Stops the player completely and removes all entries from the queue.
         """
 
-        player.kill()
+        player.queue.clear()
+        player.stop()
 
     @command_info("1.0.0", 1477180800, {
         "3.5.2": (1497712233, "Updated documentaion for this command"),

--- a/musicbot/commands/player_commands.py
+++ b/musicbot/commands/player_commands.py
@@ -45,7 +45,9 @@ class PlayerCommands:
         else:
             return Response("Hard to unpause something that's not paused, amirite?")
     
-    @command_info("4.9.9", 1508219263)    
+    @command_info("4.9.9", 1508219263, {
+        "4.9.9": (1508224340, "Fixed stop logic to avoid total kill on player")
+    })    
     async def cmd_stop(self, player):
         """
         ///|Usage
@@ -54,8 +56,7 @@ class PlayerCommands:
         Stops the player completely and removes all entries from the queue.
         """
 
-        player.queue.clear()
-        player.stop()
+        player.kill()
 
     @command_info("1.0.0", 1477180800, {
         "3.5.2": (1497712233, "Updated documentaion for this command"),

--- a/musicbot/commands/player_commands.py
+++ b/musicbot/commands/player_commands.py
@@ -56,7 +56,8 @@ class PlayerCommands:
         Stops the player completely and removes all entries from the queue.
         """
 
-        player.kill()
+        player.queue.clear()
+        player.stop()
 
     @command_info("1.0.0", 1477180800, {
         "3.5.2": (1497712233, "Updated documentaion for this command"),

--- a/musicbot/commands/queue_commands.py
+++ b/musicbot/commands/queue_commands.py
@@ -751,7 +751,9 @@ class ManipulateCommands:
 
         return Response(reply_text.format(btext, time_until))
 
-    @command_info("4.5.5", 1502073539)
+    @command_info("4.5.5", 1502073539, {
+        "4.9.9": (1508224474, "Fixed the move command description")
+    })
     async def cmd_move(self, player, from_index, to_index):
         """
         ///|Usage


### PR DESCRIPTION
- Fixing a quick bug with the `stop` command I just added in #26  (`player.kill()` will destroy the player, obviously xD)..so if one queues up some tracks later or whatnot, the player won't play without a manual execute of such and is dead. My bad! 😆 

- Added the update to the pydocs for the relevant changes + in the move command that I modified the description for earlier (forgot to update the pydoc) 
