### PR TITLE
Fixes the disconnect command error

### DIFF
--- a/musicbot/bot.py
+++ b/musicbot/bot.py
@@ -17,6 +17,7 @@ import discord
 from discord import Client
 from discord.enums import ChannelType
 from discord.utils import find
+from discord.voice_client import VoiceClient
 
 from musicbot import downloader, exceptions, localization
 from musicbot.commands.admin_commands import AdminCommands


### PR DESCRIPTION
- This was removed in 8ecce9f77fd17d804bae2696143c9c45001719e3 as part
of  a cleanup, but this is needed to avoid an error on the disconnect
command. 



```bash
Traceback (most recent call last):
  File "/home/vlexar/main/vlexar/Giesela/musicbot/bot.py", line 626, in
on_message
    response = await handler(**handler_kwargs)
  File
"/home/vlexar/main/vlexar/Giesela/musicbot/commands/admin_commands.py",
line 478, in cmd_disconnect
    await server.voice_client.disconnect()
  File
"/usr/local/lib/python3.6/dist-packages/discord/voice_client.py", line
297, in disconnect
  File "/usr/local/lib/python3.6/dist-packages/websockets/protocol.py",
line 396, in close
    def encode_data(self, data):
  File "/usr/local/lib/python3.6/dist-packages/discord/gateway.py",
line 686, in close_connection
TypeError: close_connection() got an unexpected keyword argument 'force'
```

Specifically, the call to `await server.voice_client.disconnect()`
doesn’t work without this back. 😄

/cc @siku2 